### PR TITLE
Drop needless version check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in faker-precure.gemspec
 gemspec
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
-  # NOTE: activesupport 5.x supports only ruby 2.2.2+
-  gem "activesupport", ">= 4.0.0", "< 5.0.0"
-end


### PR DESCRIPTION
rubicure v1.0.0+ requires ruby 2.2.2+
https://rubygems.org/gems/rubicure/versions/1.0.0