### PR TITLE
Stop `gem update --system`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
 bundler_args: "--jobs=2"
 cache: bundler
 before_install:
-  - gem update --system --no-document
   - gem install bundler --no-document
 script: bundle exec rspec
 branches:


### PR DESCRIPTION
rubygems v3+ requires MRI 2.3+
https://rubygems.org/gems/rubygems-update/versions/3.0.0

So build is failed on MRI < 2.3